### PR TITLE
IKDT-979 Include SNOMED in rxnorm-origin artifact

### DIFF
--- a/plugin/rxnorm-transformation-maven-plugin/src/main/java/dev/ikm/maven/RxnormTransformationMojo.java
+++ b/plugin/rxnorm-transformation-maven-plugin/src/main/java/dev/ikm/maven/RxnormTransformationMojo.java
@@ -147,7 +147,7 @@ public class RxnormTransformationMojo extends AbstractMojo {
         String rxnormId = rxnormData.getId();
 
         if (rxnormId == null || rxnormId.isEmpty()) {
-            LOG.warn("Could not extract RxNorm ID" + rxnormId);
+            LOG.warn("Could not extract RxNorm ID [{}]", rxnormData);
             return;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <origin.working.directory>${project.build.directory}/origin-sources</origin.working.directory>
         <source.version>2024-04-10</source.version>
         <source.zip>${user.home}/Downloads/Pilot-Defined-RxNorm-with-SNCT-classes-${source.version}-with-custom-annotations.owl</source.zip>
-        <snomed.source.zip>${user.home}/Downloads/SnomedCT_ManagedServiceUS_PRODUCTION_US1000124_20250301T120000Z.zip</snomed.source.zip>
+        <snomed.source.zip>${user.home}/Downloads/SnomedCT_InternationalRF2_PRODUCTION_20250301T120000Z.zip</snomed.source.zip>
         <starterSetLocation>${user.home}/Downloads</starterSetLocation>
         <starterSet>5-1RxNormStarterSet.zip</starterSet>
         <fieldCategoriesStarterSetLocation>${user.home}/Downloads</fieldCategoriesStarterSetLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,11 @@
 
     <modules>
         <module>plugin</module>
+        <module>rxnorm-origin</module>
         <module>rxnorm-starterdata</module>
         <module>rxnorm-pipeline</module>
         <module>rxnorm-integration</module>
-        <!--module>rxnorm-export</module-->
+        <module>rxnorm-export</module>
     </modules>
 
     <properties>
@@ -34,6 +35,7 @@
         <maven-plugin-plugin.version>3.13.0</maven-plugin-plugin.version>
         <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+        <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <jupiter.version>5.12.0</jupiter.version>
         <!-- starter data -->
         <tinkar-starter-data.groupId>dev.ikm.data.tinkar</tinkar-starter-data.groupId>
@@ -44,13 +46,19 @@
         <origin.working.directory>${project.build.directory}/origin-sources</origin.working.directory>
         <source.version>2024-04-10</source.version>
         <source.zip>${user.home}/Downloads/Pilot-Defined-RxNorm-with-SNCT-classes-${source.version}-with-custom-annotations.owl</source.zip>
-        <origin.namespace>3094dbd1-60cf-44a6-92e3-0bb32ca4d3de</origin.namespace>
+        <snomed.source.zip>${user.home}/Downloads/SnomedCT_ManagedServiceUS_PRODUCTION_US1000124_20250301T120000Z.zip</snomed.source.zip>
         <starterSetLocation>${user.home}/Downloads</starterSetLocation>
         <starterSet>5-1RxNormStarterSet.zip</starterSet>
         <fieldCategoriesStarterSetLocation>${user.home}/Downloads</fieldCategoriesStarterSetLocation>
         <fieldCategoriesStarterSet>FieldCategories-nonprimordial-unreasoned-pb.zip</fieldCategoriesStarterSet>
         <dataStoreLocation>${project.basedir}/../target</dataStoreLocation>
         <dataStore>rxnorm</dataStore>
+
+        <!-- origin -->
+        <packager.name>IKM Dev</packager.name>
+        <origin.url>https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html</origin.url>
+        <origin.namespace>3094dbd1-60cf-44a6-92e3-0bb32ca4d3de</origin.namespace>
+
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/rxnorm-origin/pom.xml
+++ b/rxnorm-origin/pom.xml
@@ -14,18 +14,6 @@
 
     <name>rxnorm-origin</name>
 
-    <!--    <distributionManagement>-->
-    <!--        <repository>-->
-    <!--            <id>nexus-releases</id>-->
-    <!--            <name>Nexus Releases</name>-->
-    <!--            <url></url>-->
-    <!--        </repository>-->
-    <!--        <snapshotRepository>-->
-    <!--            <id>nexus-snapshots</id>-->
-    <!--            <name>Nexus Snapshots</name>-->
-    <!--            <url></url>-->
-    <!--        </snapshotRepository>-->
-    <!--    </distributionManagement>-->
     <build>
         <plugins>
             <!-- Unzip source data -->
@@ -34,12 +22,22 @@
                 <artifactId>tinkar-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>process-origin</id>
+                        <id>process-rxnorm-origin</id>
                         <goals>
                             <goal>unzip-source</goal>
                         </goals>
                         <configuration>
                             <source>${source.zip}</source>
+                            <outputDirectory>${origin.working.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>process-snomed-origin</id>
+                        <goals>
+                            <goal>unzip-source</goal>
+                        </goals>
+                        <configuration>
+                            <source>${snomed.source.zip}</source>
                             <outputDirectory>${origin.working.directory}</outputDirectory>
                         </configuration>
                     </execution>
@@ -125,15 +123,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Deploy to Nexus -->
-            <!--            <plugin>-->
-            <!--                <groupId>org.apache.maven.plugins</groupId>-->
-            <!--                <artifactId>maven-deploy-plugin</artifactId>-->
-            <!--                <version>3.1.2</version>-->
-            <!--                <configuration>-->
-
-            <!--                </configuration>-->
-            <!--            </plugin>-->
         </plugins>
     </build>
 </project>

--- a/rxnorm-owl-transform/pom.xml
+++ b/rxnorm-owl-transform/pom.xml
@@ -30,7 +30,7 @@
                             <goal>run-owl-transformer</goal>
                         </goals>
                         <configuration>
-                            <dataStore>${user.home}/Solor/generated-data</dataStore>
+                            <dataStore>${dataStoreLocation}/${dataStore}</dataStore>
                         </configuration>
                     </execution>
                 </executions>

--- a/rxnorm-pipeline/pom.xml
+++ b/rxnorm-pipeline/pom.xml
@@ -30,7 +30,8 @@
                 <configuration>
                     <namespaceString>${origin.namespace}</namespaceString>
                     <datastorePath>${dataStoreLocation}/${dataStore}</datastorePath>
-                    <inputDirectoryPath>${user.home}/.m2/repository/dev/ikm/snomedct/snomed-ct-origin/${project.version}/snomed-ct-origin-${project.version}-data.zip</inputDirectoryPath>
+                    <!-- SNOMED is packaged in rxnorm-origin -->
+                    <inputDirectoryPath>${user.home}/.m2/repository/dev/ikm/rxnorm/rxnorm-origin/${project.version}/rxnorm-origin-${project.version}-data.zip</inputDirectoryPath>
                     <dataOutputPath>${project.build.directory}</dataOutputPath>
                 </configuration>
                 <executions>


### PR DESCRIPTION
- This is a continuation of PR #15 which added the snomed-ct-transformation-maven-plugin to rxnorm-pipeline, and snomed-ct-starterdata-maven-plugin to rxnorm-starterdata.

- Added rxnorm-origin and rxnorm-export modules.

- Include snomed dataset in rxnorm-origin artifact (build does not depend on snomed-ct-origin-data)
