### PR TITLE
IKDT-1163 RxNorm origin ZIP should include OWL file

### DIFF
--- a/plugin/rxnorm-transformation-maven-plugin/src/main/java/dev/ikm/maven/RxnormTransformationMojo.java
+++ b/plugin/rxnorm-transformation-maven-plugin/src/main/java/dev/ikm/maven/RxnormTransformationMojo.java
@@ -87,11 +87,11 @@ public class RxnormTransformationMojo extends AbstractMojo {
         File datastore = new File(datastorePath);
         this.rxnormModule = EntityProxy.Concept.make(PublicIds.of(UUID.fromString(RxnormUtility.RXNORM_MODULE)));
 
-//        try {
-//            unzipRawData(inputDirectoryPath);
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
+        try {
+            unzipRawData(inputDirectoryPath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         initializeDatastore(datastore);
         EntityService.get().beginLoadPhase();

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
         <!-- origin -->
         <origin.working.directory>${project.build.directory}/origin-sources</origin.working.directory>
         <source.version>2024-04-10</source.version>
-        <source.zip>${user.home}/Downloads/Pilot-Defined-RxNorm-with-SNCT-classes-${source.version}-with-custom-annotations.owl</source.zip>
+        <rxnormOwl>Pilot-Defined-RxNorm-with-SNCT-classes-${source.version}-with-custom-annotations.owl</rxnormOwl>
+        <source.zip>${user.home}/Downloads/${rxnormOwl}</source.zip>
         <starterSetLocation>${user.home}/Downloads</starterSetLocation>
         <starterSet>RxNorm Starter Export 07072025.zip</starterSet>
         <dataStoreLocation>${project.basedir}/../../snomed-ct-data/target</dataStoreLocation>

--- a/rxnorm-origin/pom.xml
+++ b/rxnorm-origin/pom.xml
@@ -22,16 +22,6 @@
                 <artifactId>tinkar-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>process-rxnorm-origin</id>
-                        <goals>
-                            <goal>unzip-source</goal>
-                        </goals>
-                        <configuration>
-                            <source>${source.zip}</source>
-                            <outputDirectory>${origin.working.directory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>create-origin-manifest</id>
                         <goals>
                             <goal>generate-manifest-resource</goal>
@@ -83,6 +73,12 @@
                                             </includes>
                                         </fileSet>
                                     </fileSets>
+                                    <files>
+                                        <file>
+                                            <outputDirectory>src</outputDirectory>
+                                            <source>${source.zip}</source>
+                                        </file>
+                                    </files>
                                     <includeBaseDirectory>false</includeBaseDirectory>
                                 </inlineDescriptor>
                             </inlineDescriptors>

--- a/rxnorm-pipeline/pom.xml
+++ b/rxnorm-pipeline/pom.xml
@@ -29,7 +29,7 @@
                 <version>1.0.0-SNAPSHOT</version>
                 <configuration>
                     <namespaceString>${origin.namespace}</namespaceString>
-                    <rxnormOwl>${source.zip}</rxnormOwl>
+                    <rxnormOwl>${project.build.directory}/src/${rxnormOwl}</rxnormOwl>
                     <datastorePath>${dataStoreLocation}/${dataStore}</datastorePath>
                     <inputDirectoryPath>${user.home}/.m2/repository/dev/ikm/rxnorm/rxnorm-origin/${project.version}/rxnorm-origin-${project.version}-data.zip</inputDirectoryPath>
                     <dataOutputPath>${project.build.directory}</dataOutputPath>


### PR DESCRIPTION
RxNorm origin data is an OWL file, not a ZIP like the other datasets. We need to package the OWL file into the origin ZIP for the pipeline, instead of referencing from the local downloads path.

This PR adds the OWL file to the origin ZIP, and enables a subsequent unzip in the transformation mojo.